### PR TITLE
adding a makefile and also dockerizing the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,13 @@
 
 # Test binary, built with `go test -c`
 *.test
+!Dockerfile.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Executable built from make build
+origin_backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.16-alpine
+WORKDIR /app
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+COPY . ./
+RUN go build -o main
+CMD   ["./main"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,8 @@
+FROM golang:1.16-alpine
+WORKDIR /app
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+RUN apk add build-base
+COPY . ./
+RUN go build -o main

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+TESTS?=$$(go list ./... | egrep -v "types")
+BINARY=origin_backend
+ENTRY=main.go
+
+default: build
+
+#host commands
+
+build:
+	go build -o $(BINARY) $(ENTRY)
+
+run: build
+	./$(BINARY)
+
+clean:
+	go clean
+	rm -f $(BINARY) cover.out coverage.html
+
+test:
+	go test -v $(TESTS) -failfast
+
+cover:
+	go test -v $(TESTS) -failfast -coverprofile=cover.out
+	go tool cover -html=cover.out -o coverage.html
+
+#dockerized commands
+
+docker/build:
+	docker build -t origin_backend .
+
+docker/build-test:
+	docker build -t origin_backend_test . -f Dockerfile.test
+
+docker/run: docker/build
+	docker run --rm --name origin_backend -p 8080:8080 origin_backend
+
+docker/clean:
+	docker rmi -f origin_backend
+	docker rmi -f origin_backend_test
+	
+docker/test: docker/build-test
+	docker run --rm --name origin_backend_test origin_backend_test go test -v $(TESTS) -failfast


### PR DESCRIPTION
What/Why: To ease up the process of running and debugging the api, a makefile was added to organize commands and Dockerfiles were added to run the application and its tests in containers.
ref : [task 007](https://trello.com/c/wkzofE6Q/8-007-dockerize-the-application-execution) and [task 013](https://trello.com/c/6EYUX0rE/14-013-add-a-makefile)