### PR TITLE
feat/useful-request-logging

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"log"
+
 	"github.com/gorilla/mux"
 	"github.com/victormagalhaess/origin-backend-take-home-assignment/pkg/api/controllers"
+	"github.com/victormagalhaess/origin-backend-take-home-assignment/pkg/api/middlewares"
 )
 
 type Application struct {
@@ -17,4 +20,5 @@ func (a *Application) InitializeRouter() {
 func (a *Application) initializeRoutes() {
 	a.Router.HandleFunc("/api/v1/healthcheck", controllers.Healthcheck).Methods("GET")
 	a.Router.HandleFunc("/api/v1/risk", controllers.Risk).Methods("POST")
+	a.Router.Use(middlewares.Logger(log.Default()))
 }

--- a/pkg/api/middlewares/logger.go
+++ b/pkg/api/middlewares/logger.go
@@ -1,0 +1,17 @@
+package middlewares
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func Logger(log *log.Logger) mux.MiddlewareFunc {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL)
+			h.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
What/Why: Adding a middleware that logs information about the requests when they're received.
ref : [task 015](https://trello.com/c/3H336BPC/17-015-useful-logging-on-start-end-and-on-request)