### PR TITLE
fix/wrong-pipeline-filling

### DIFF
--- a/pkg/api/services/risk.go
+++ b/pkg/api/services/risk.go
@@ -27,7 +27,9 @@ func Risk(userInfo model.UserPersonalInformation) ([]byte, error) {
 			Eligibility: true,
 		},
 	}
-	engine.InitializePipeline()
+	if len(engine.Pipeline.RiskSteps) == 0 {
+		engine.InitializePipeline()
+	}
 	engine.ExecutePipeline(userInfo, insuranceSteps)
 	response, err := json.Marshal(insuranceSteps.MapInsuranceAnalisysToRiskProfile())
 	if err != nil {

--- a/pkg/api/services/risk_extended_test.go
+++ b/pkg/api/services/risk_extended_test.go
@@ -51,7 +51,7 @@ var testRiskScenarios = []struct {
 				Year: time.Now().Year() - 2,
 			},
 		},
-		output: "{\"auto\":\"regular\",\"disability\":\"regular\",\"home\":\"regular\",\"life\":\"responsible\"}",
+		output: "{\"auto\":\"regular\",\"disability\":\"regular\",\"home\":\"regular\",\"life\":\"regular\"}",
 	},
 	{
 		userInfo: model.UserPersonalInformation{
@@ -171,7 +171,7 @@ var testRiskScenarios = []struct {
 				Year: time.Now().Year() - 8,
 			},
 		},
-		output: "{\"auto\":\"economic\",\"disability\":\"economic\",\"home\":\"economic\",\"life\":\"responsible\"}",
+		output: "{\"auto\":\"regular\",\"disability\":\"regular\",\"home\":\"regular\",\"life\":\"responsible\"}",
 	},
 	{
 		userInfo: model.UserPersonalInformation{
@@ -198,7 +198,7 @@ var testRiskScenarios = []struct {
 			},
 			Income:        20180000,
 			MaritalStatus: "married",
-			RiskQuestions: []int8{0, 1, 1},
+			RiskQuestions: []int8{0, 1, 0},
 			Vehicle: &model.Vehicle{
 				Year: time.Now().Year() - 2022,
 			},


### PR DESCRIPTION
What/Why: Making the pipeline fill with steps only once. Because there were no validation, the pipeline were being filled with copies of the same steps every time the pipeline was executed, making the steps that interfere in score (as age) being apllied multiple times. 
ref : [task 017](https://trello.com/c/NhRhLKjB/19-017-fix-pipeline-filling-process)