### PR TITLE
feat/env-var-port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TESTS?=$$(go list ./... | egrep -v "mock|docs")
 BINARY=origin_backend
 ENTRY=main.go
+PORT=8080
 
 default: build
 
@@ -13,7 +14,7 @@ build: install
 	go build -o $(BINARY) $(ENTRY)
 
 run: build
-	./$(BINARY)
+	PORT=$(PORT) ./$(BINARY)
 
 clean:
 	go clean
@@ -38,7 +39,7 @@ docker/build-test:
 	docker build -t origin_backend_test . -f Dockerfile.test
 
 docker/run: docker/build
-	docker run --rm --name origin_backend -p 8080:8080 origin_backend
+	docker run -e PORT=$(PORT) --rm --name origin_backend  -p $(PORT):$(PORT) origin_backend
 
 docker/clean:
 	docker rmi -f origin_backend

--- a/main.go
+++ b/main.go
@@ -27,6 +27,12 @@ import (
 // @host localhost:8080
 
 func main() {
+	//parse the port flag from the command line
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
 	wait := time.Second * 10 //default time to wait connections to close before shutdown
 
 	application := api.Application{}
@@ -35,7 +41,7 @@ func main() {
 
 	// setting connection timeouts for http server
 	server := &http.Server{
-		Addr:         ":8080",
+		Addr:         ":" + port,
 		WriteTimeout: time.Second * 15,
 		ReadTimeout:  time.Second * 15,
 		IdleTimeout:  time.Second * 60,
@@ -44,6 +50,7 @@ func main() {
 
 	// starting http server in a goroutine so that it won't block
 	go func() {
+		log.Println("Starting server on port " + port)
 		if err := server.ListenAndServe(); err != nil {
 			log.Println(err)
 		}


### PR DESCRIPTION
What/Why: Loading the PORT variable from the environment.
ref : [task 018](https://trello.com/c/dlugVgiB/20-018-load-the-port-var-from-environment)